### PR TITLE
Add example of baz being parented differently

### DIFF
--- a/src/foo/foo.model.ts
+++ b/src/foo/foo.model.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { Bar } from 'src/bar/bar.model';
+import { Baz } from 'src/baz/baz.model';
 
 @ObjectType()
 export class Foo {
@@ -8,4 +9,7 @@ export class Foo {
 
   @Field((type) => Bar)
   bar: Bar;
+
+  @Field(type => Baz)
+  baz: Baz;
 }

--- a/src/foo/foo.resolver.ts
+++ b/src/foo/foo.resolver.ts
@@ -1,4 +1,4 @@
-import { Query, Resolver } from '@nestjs/graphql';
+import { Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { Foo } from './foo.model';
 import { FooProvider } from './foo.provider';
 
@@ -9,5 +9,13 @@ export class FooResolver {
   @Query((returns) => Foo)
   async foo() {
     return await this.fooProvider.getAFoo();
+  }
+
+  @ResolveField()
+  baz() {
+    return {
+      baz: 'im doing different things',
+      id: 'special',
+    }
   }
 }


### PR DESCRIPTION
A `@ResolveField` annotation will override the behavior of `@ResolveObjectType`